### PR TITLE
fixes for devcontainer build problems

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,16 +2,17 @@ FROM espressif/idf
 
 ARG DEBIAN_FRONTEND=nointeractive
 
-RUN apt-get update \
-  && apt install -y -q \
-  cmake \
-  git \
-  hwdata \
-  libglib2.0-0 \
-  libnuma1 \
-  libpixman-1-0 \
-  linux-tools-virtual \
-  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y\
+    && apt upgrade -y -q \
+    && apt install -y -q \
+    cmake \
+    git \
+    hwdata \
+    libglib2.0-0 \
+    libnuma1 \
+    libpixman-1-0 \
+    linux-tools-virtual \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/local/bin/usbip usbip `ls /usr/lib/linux-tools/*/usbip | tail -n1` 20
 
@@ -25,19 +26,18 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
 RUN wget --no-verbose ${QEMU_URL} \
-  && echo "${QEMU_SHA256} *${QEMU_DIST}" | sha256sum --check --strict - \
-  && tar -xf $QEMU_DIST -C /opt \
-  && rm ${QEMU_DIST}
+    && echo "${QEMU_SHA256} *${QEMU_DIST}" | sha256sum --check --strict - \
+    && tar -xf $QEMU_DIST -C /opt \
+    && rm ${QEMU_DIST}
 
 ENV PATH=/opt/qemu/bin:${PATH}
 
 RUN echo "source /opt/esp/idf/export.sh > /dev/null 2>&1" >> ~/.bashrc
 
-RUN . /opt/esp/python_env/idf5.1_py3.8_env/bin/activate \
-  && pip install littlefs-python
 
+# LittleFS
+# pip install littlefs-python moved to postCreateCommand to avoid issues with parallel builds
 RUN echo "alias build='python /workspace/tools/filesystem_generate.py'" >> ~/.bashrc 
 
 ENTRYPOINT [ "/opt/esp/entrypoint.sh" ]
-
 CMD ["/bin/bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,36 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/ubuntu
 {
-	"name": "Wokwi Micropython ESP32",
-	"build": {
-		"dockerfile": "Dockerfile"
-	},
-	"extensions": [
-		"ms-vscode.cpptools",
-		"espressif.esp-idf-extension",
-		"Wokwi.wokwi-vscode",
-		"ms-python.python"
-	],
-	"mounts": [
-		"source=extensionCache,target=/root/.vscode-server/extensions,type=volume"
-	],
-	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
-	"workspaceFolder": "/workspace",
-	"settings": {
-		"terminal.integrated.defaultProfile.linux": "bash",
-		"idf.espIdfPath": "/opt/esp/idf",
-		"idf.customExtraPaths": "",
-		"idf.pythonBinPath": "/opt/esp/python_env/idf5.1_py3.8_env/bin/python",
-		"idf.toolsPath": "/opt/esp",
-		"idf.gitPath": "/usr/bin/git",
-		"python.defaultInterpreterPath": "/opt/esp/python_env/idf5.1_py3.8_env/bin/python"
-	},
-	"runArgs": [
-		"--privileged"
-	]
+    "name": "Wokwi Micropython ESP32",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "bash",
+                "idf.espIdfPath": "/opt/esp/idf",
+                "idf.customExtraPaths": "",
+                "idf.pythonBinPath": "${IDF_PYTHON_ENV_PATH}/bin/python",
+                "idf.toolsPath": "/opt/esp",
+                "idf.gitPath": "/usr/bin/git",
+                "python.defaultInterpreterPath": "${IDF_PYTHON_ENV_PATH}/bin/python"
+            },
+            "extensions": [
+                "Wokwi.wokwi-vscode",
+                "ms-python.python"
+            ]
+        }
+    },
+    "mounts": [
+        "source=extensionCache,target=/root/.vscode-server/extensions,type=volume"
+    ],
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+    "workspaceFolder": "/workspace",
+    "runArgs": [
+        "--privileged"
+    ],
+    "postCreateCommand": ". ${IDF_PYTHON_ENV_PATH}/bin/activate && pip install littlefs-python"
 }


### PR DESCRIPTION
There are a number of issues with the devcontainer build that I fixed, I hope they may be of use to you. 

- hardcoded version in paths for the IDF version
- buildx builds in parallel, while the dockerfile assumes linear 


hope they are of use.